### PR TITLE
Tolerate update() calls the speaker doesn't answer, keyed by source

### DIFF
--- a/src/pywam/speaker.py
+++ b/src/pywam/speaker.py
@@ -24,7 +24,12 @@ from pywam.lib.const import (
     Feature,
 )
 from pywam.lib.equalizer import EqualizerPreset
-from pywam.lib.exceptions import ApiCallError, FeatureNotSupportedError, PywamError
+from pywam.lib.exceptions import (
+    ApiCallError,
+    ApiCallTimeoutError,
+    FeatureNotSupportedError,
+    PywamError,
+)
 
 if TYPE_CHECKING:
     from pywam.lib.api_response import ApiResponse
@@ -82,6 +87,10 @@ class Speaker:
         self.attribute = WamAttributes(self, self.device)
         self.events = WamEvents(self)
         self.client = WamClient(self)
+        # (source, api-method) pairs the speaker doesn't answer — player/radio
+        # queries are meaningless in an external input like HDMI, but valid in
+        # Wi-Fi/Bluetooth. Keyed by source so a source change re-enables them.
+        self._unsupported: set[tuple[str | None, str]] = set()
 
     async def __aenter__(self):
         """Enter async context manager."""
@@ -414,6 +423,35 @@ class Speaker:
     # Update
     # ******************************************************************
 
+    async def _update_optional(self, call: api_call.ApiCall) -> None:
+        """Request an attribute that only some sources expose.
+
+        Player/radio queries (shuffle, repeat, preset list) are meaningless
+        when the active source is an external input (e.g. HDMI on a soundbar),
+        where the speaker simply doesn't answer them and one unanswered call
+        would otherwise abort the whole update(). Skip such a call once it has
+        timed out for the CURRENT source — but key it to that source, so
+        switching to a source that does support it (Wi-Fi / Bluetooth playback)
+        re-enables the query on the next update rather than nerfing it for the
+        life of the connection.
+
+        NB: relies on get_func() being requested before the optional calls in
+        update_player_info(), so self.attribute._function is current.
+        """
+        key = (self.attribute._function, call.method)
+        if key in self._unsupported:
+            return
+        try:
+            await self.client.request(call)
+        except ApiCallTimeoutError:
+            _LOGGER.debug(
+                "Speaker did not answer '%s' in source '%s'; skipping it for "
+                "that source until the source changes.",
+                call.method,
+                self.attribute._function,
+            )
+            self._unsupported.add(key)
+
     async def update(self) -> None:
         """Update all speaker properties.
 
@@ -453,8 +491,8 @@ class Speaker:
         await self.client.request(api_call.get_func())
         await self.client.request(api_call.get_volume())
         await self.client.request(api_call.get_mute())
-        await self.client.request(api_call.get_shuffle_mode())
-        await self.client.request(api_call.get_repeat_mode())
+        await self._update_optional(api_call.get_shuffle_mode())
+        await self._update_optional(api_call.get_repeat_mode())
         await self.client.request(api_call.get_current_eq_mode())
 
     async def update_media_info(self) -> None:
@@ -467,8 +505,10 @@ class Speaker:
     async def update_speaker_settings(self) -> None:
         """Update speaker settings."""
         # Favorites. At the moment only TuneIn presets are supported.
-        await self.client.request(api_call.set_select_radio())
-        await self.client.request(api_call.get_preset_list(0, 30))
+        # These don't apply when the active source isn't a radio/player
+        # (e.g. a soundbar in an HDMI source), so tolerate no answer.
+        await self._update_optional(api_call.set_select_radio())
+        await self._update_optional(api_call.get_preset_list(0, 30))
         # Equalizer
         await self.client.request(api_call.get_7band_eq_list())
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+"""Pytest configuration for the pywam test-suite.
+
+The library lives under ``<repo>/src/pywam`` so we must put that ``src``
+directory on ``sys.path`` before the tests import anything.
+
+To let the SAME test-suite run against a different checkout (e.g. a
+``master`` worktree, to prove a fix actually changes behaviour), the src
+directory can be overridden with the ``PYWAM_SRC`` environment variable.
+When it is unset we fall back to the ``src`` directory that sits next to
+this ``tests`` directory.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+_here = os.path.dirname(os.path.abspath(__file__))
+_default_src = os.path.join(os.path.dirname(_here), "src")
+
+PYWAM_SRC = os.environ.get("PYWAM_SRC", _default_src)
+sys.path.insert(0, PYWAM_SRC)

--- a/tests/test_fixes.py
+++ b/tests/test_fixes.py
@@ -1,0 +1,99 @@
+"""Regression tests for the `fix/tolerate-unanswered-update-calls` branch.
+
+`update_player_info()` / `update_speaker_settings()` must tolerate the
+speaker ignoring optional queries (shuffle/repeat/presets) that are
+meaningless for the active source, caching the skip keyed by source so a
+source change retries it. Each test PASSES on this branch and FAILS on
+`master` (via the ``PYWAM_SRC`` env var in ``conftest.py``).
+
+There is no real speaker; the network client / socket layer is mocked.
+"""
+from __future__ import annotations
+
+import pytest
+
+from pywam.lib import api_call
+from pywam.lib.api_response import ApiResponse
+from pywam.lib.exceptions import ApiCallTimeoutError
+from pywam.speaker import Speaker
+
+TEST_IP = "192.168.1.100"
+
+
+def _ok(method: str = "", data=None) -> ApiResponse:
+    """Build a benign, successful ApiResponse."""
+    if data is None:
+        data = {"@result": "ok"}
+    return ApiResponse(method=method, success=True, data=data)
+
+
+# ======================================================================
+# Fix: update() tolerates source-unsupported calls, keyed by source
+# ======================================================================
+
+
+class _RecordingClient:
+    """Stand-in for WamClient.request that records calls and can time out.
+
+    Methods listed in ``timeout_methods`` raise ApiCallTimeoutError (as a
+    real speaker does when the query is meaningless for the active
+    source, e.g. shuffle/repeat/presets on an HDMI input); every other
+    call returns a benign successful response.
+    """
+
+    def __init__(self, timeout_methods: set[str]) -> None:
+        self.timeout_methods = timeout_methods
+        self.calls: list[str] = []
+
+    async def request(self, call: api_call.ApiCall) -> ApiResponse:
+        self.calls.append(call.method)
+        if call.method in self.timeout_methods:
+            raise ApiCallTimeoutError(f"({TEST_IP}) No response from speaker")
+        return _ok(call.expected_response)
+
+
+@pytest.mark.asyncio
+async def test_update_player_info_tolerates_unanswered_calls_per_source():
+    """update_player_info() must not abort when the speaker ignores the
+    optional shuffle/repeat queries (HDMI source), and must cache the
+    skip keyed by source so a source change retries it."""
+    speaker = Speaker(TEST_IP)
+    fake = _RecordingClient(timeout_methods={"GetShuffleMode", "GetRepeatMode"})
+    speaker.client.request = fake.request  # type: ignore[assignment]
+
+    # Active source is an external HDMI input.
+    speaker.attribute._function = "hdmi"
+
+    # On this branch this completes; on master the raw request() for
+    # GetShuffleMode raises ApiCallTimeoutError straight out.
+    await speaker.update_player_info()
+
+    # The unanswered optional calls were cached, keyed by the source.
+    assert ("hdmi", "GetShuffleMode") in speaker._unsupported
+    assert ("hdmi", "GetRepeatMode") in speaker._unsupported
+
+    # A second pass in the SAME source skips them (request not re-issued).
+    calls_before = fake.calls.count("GetShuffleMode")
+    await speaker.update_player_info()
+    assert fake.calls.count("GetShuffleMode") == calls_before
+
+    # Changing the source re-enables the query (per-source, not permanent).
+    speaker.attribute._function = "wifi"
+    await speaker.update_player_info()
+    assert fake.calls.count("GetShuffleMode") == calls_before + 1
+
+
+@pytest.mark.asyncio
+async def test_update_speaker_settings_tolerates_unanswered_preset_call():
+    """update_speaker_settings() must tolerate the speaker ignoring the
+    preset-list query in a non-radio source."""
+    speaker = Speaker(TEST_IP)
+    fake = _RecordingClient(timeout_methods={"GetPresetList"})
+    speaker.client.request = fake.request  # type: ignore[assignment]
+
+    speaker.attribute._function = "hdmi"
+
+    # Completes on this branch; raises ApiCallTimeoutError on master.
+    await speaker.update_speaker_settings()
+
+    assert ("hdmi", "GetPresetList") in speaker._unsupported


### PR DESCRIPTION
On a soundbar in an external input (e.g. HDMI), the speaker doesn't answer player/radio queries like `GetShuffleMode` / `GetRepeatMode` / `GetPresetList` — there's no player in that mode. `Speaker.update()` issues those unconditionally, so one timeout raises `ApiCallTimeoutError` and aborts the whole update. That makes models like the HW-Q90R impossible to add, since the config flow calls `update()` to validate.

This skips such a call when it times out and remembers it **keyed by the current source**, so it isn't retried every poll — but switching to a source that *does* support it (Wi-Fi/Bluetooth) re-enables the query on the next update, rather than disabling it for the life of the connection.

Verified on a HW-Q90R (fw `HW-Q90RWWB-1012.6`): in HDMI, `update()` learns `(hdmi1, GetShuffleMode/GetRepeatMode/GetPresetList)` — first update ~15s (waits the timeouts out once), then ~0.4s; volume/mute/source/sound_mode populate, shuffle/repeat/media sit at `None`. A source change yields new keys and retries.

Small change — a `_update_optional` helper in `speaker.py` plus its two call sites. No API changes.
