### PR TITLE
Don't block the listener when a trailing message can't be queued

### DIFF
--- a/src/pywam/client.py
+++ b/src/pywam/client.py
@@ -307,7 +307,21 @@ class WamClient:
                 ApiResponse object to be returned to caller.
         """
         if self._response_queue:
-            await self._response_queue.put(api_response)
+            try:
+                self._response_queue.put_nowait(api_response)
+            except asyncio.QueueFull:
+                # The waiter has already received (or will match) its
+                # response; this is a trailing message — e.g. a pushed event
+                # arriving right after the matched response in the same socket
+                # read. It was already handed to subscribers by
+                # _dispatch_event() above, so drop it here instead of blocking
+                # the listener task on a full, unconsumed queue (which would
+                # wedge the connection until a full reconnect).
+                _LOGGER.debug(
+                    "(%s) response queue full; dropping already-dispatched "
+                    "trailing message",
+                    self._ip,
+                )
 
     async def _wait_for_response(self, api_call: ApiCall) -> ApiResponse:
         """ Wait for the correct response from speaker.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+"""Pytest configuration for the pywam test-suite.
+
+The library lives under ``<repo>/src/pywam`` so we must put that ``src``
+directory on ``sys.path`` before the tests import anything.
+
+To let the SAME test-suite run against a different checkout (e.g. a
+``master`` worktree, to prove a fix actually changes behaviour), the src
+directory can be overridden with the ``PYWAM_SRC`` environment variable.
+When it is unset we fall back to the ``src`` directory that sits next to
+this ``tests`` directory.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+_here = os.path.dirname(os.path.abspath(__file__))
+_default_src = os.path.join(os.path.dirname(_here), "src")
+
+PYWAM_SRC = os.environ.get("PYWAM_SRC", _default_src)
+sys.path.insert(0, PYWAM_SRC)

--- a/tests/test_fixes.py
+++ b/tests/test_fixes.py
@@ -1,0 +1,53 @@
+"""Regression test for the `fix/listener-deadlock` branch.
+
+`_return_response()` must not block the listener when the response queue
+is already at capacity (trailing-message case). The test PASSES on this
+branch and FAILS on `master` (via the ``PYWAM_SRC`` env var in
+``conftest.py``).
+
+There is no real speaker; the network client / socket layer is mocked.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from pywam.lib.api_response import ApiResponse
+from pywam.speaker import Speaker
+
+TEST_IP = "192.168.1.100"
+
+
+def _ok(method: str = "", data=None) -> ApiResponse:
+    """Build a benign, successful ApiResponse."""
+    if data is None:
+        data = {"@result": "ok"}
+    return ApiResponse(method=method, success=True, data=data)
+
+
+# ======================================================================
+# Fix: listener does not deadlock on a full response queue
+# ======================================================================
+
+
+@pytest.mark.asyncio
+async def test_return_response_does_not_block_on_full_queue():
+    """_return_response() must not block the listener when the response
+    queue is already at capacity (trailing message case)."""
+    speaker = Speaker(TEST_IP)
+    client = speaker.client
+
+    # Pre-fill the single-slot queue to capacity.
+    client._response_queue = asyncio.Queue(1)
+    client._response_queue.put_nowait(_ok("MuteStatus"))
+
+    trailing = _ok("MuteStatus")
+
+    # On this branch put_nowait -> QueueFull is caught and the message is
+    # dropped, so this returns immediately. On master `await queue.put()`
+    # blocks forever on the full queue, so wait_for raises TimeoutError.
+    await asyncio.wait_for(client._return_response(trailing), timeout=1.0)
+
+    # The original item is still there (trailing message was dropped).
+    assert client._response_queue.qsize() == 1


### PR DESCRIPTION
`_return_response` uses a blocking `put()` on the `maxsize=1` response queue. Once `_wait_for_response` matches and returns, any further message processed in the same socket read — e.g. a pushed event arriving right after the matched response, common on a speaker shared by multiple clients — hits `put()` on a full, now-unconsumed queue and **blocks the receive loop forever**. The connection then wedges (all later requests time out; the speaker looks offline) until a full reconnect.

Fix: use `put_nowait` and drop on `QueueFull`. The message was already dispatched to subscribers by `_dispatch_event()` *before* `_return_response()`, so dropping it from the response queue loses no state — it only prevents the listener from blocking.

One-line-ish change in `client.py`; response path smoke-tested against a live speaker (name/model/volume still returned).
